### PR TITLE
Fix name/val parsing when value is quoted

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -174,7 +174,7 @@ function parseNameVal(cmd) {
                 return false;
             }
             var parts = word.split('=');
-            cmd.args[parts[0]] = parts.slice(1).join('=');
+            cmd.args[parts[0]] = parts.slice(1).join('=').replace(/^"(.+?)"$/g, '$1');
         }
     }
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,4 +12,5 @@ EXPOSE 80
 EXPOSE 9989
 VOLUME /srv/data2
 RUN cd /srv/app && make build2
+LABEL name="Some Name"
 ENTRYPOINT node index.js

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -68,7 +68,7 @@ tape('should parse a Dockerfile', function (t) {
   var dockerFile = fs.readFileSync(dname + '/Dockerfile', 'utf8');
   var commands = dockerfileParser.parse(dockerFile);
 
-  var numCommands = 15;
+  var numCommands = 16;
   t.equal(commands.length, numCommands, 'Check number of commands');
 
   var from = commands[0];
@@ -84,6 +84,11 @@ tape('should parse a Dockerfile', function (t) {
   t.equal(Object.keys(env.args).length, 2, 'ENV command has 2 keys');
   t.equal(env.args['VAR2'], '20', 'ENV VAR2 check');
   t.equal(env.args['VAR3'], '30', 'ENV VAR3 check');
+
+  var label = commands[14];
+  t.equal(label.name, 'LABEL', '15th command is LABEL');
+  t.equal(Object.keys(label.args).length, 1, 'LABEL command has 1 key');
+  t.equal(label.args['name'], 'Some Name', 'LABEL name check');
 
   t.equal(commands[numCommands-1].name, 'ENTRYPOINT',
             'Last command should be ENTRYPOINT');


### PR DESCRIPTION
ref zeit/now-cli#682

One of our users reported that their `LABEL` command was being incorrectly parsed. It appears quoted values in name/value pairs don't have their quotes removed when being parsed (although it _does_ appear the quoted are being honored).

This PR fixes that by stripping the quotes from the beginning and end if they exist.