### PR TITLE
Add all available types for command arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 export interface CommandEntry {
     name: string;
-    args: string[];
+    args: string | string[] | { [key: string]: string };
     lineno: number;
     raw: string;
     error?: string;


### PR DESCRIPTION
The arguments for a command can be either a string, array or map, (going by the README) so
these types have been added to the typings.

Signed-off-by: Cameron Diver <cameron@resin.io>