### PR TITLE
Parsing commands with question mark fails (fixes #9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-file-parser",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Parses a Dockerfile and returns an array of commands.",
   "keywords": [
     "dockerfile",

--- a/parser.js
+++ b/parser.js
@@ -369,7 +369,7 @@ function parse(contents, options) {
     var i;
     var line;
     var lineno;
-    var lines = contents.split(/[\r?\n]/);
+    var lines = contents.split(/\r?\n/);
     var lookingForDirectives = true;
     var parseOptions = {};
     var parseResult;

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -167,3 +167,19 @@ tape('escape parser directive', function (t) {
 
   t.end();
 });
+
+
+tape('correctly parses commands with question mark', function (t) {
+  var lines = [
+    'FROM cirrusci/wget',
+    '',
+    'RUN wget http://google.com?hello=world'
+  ];
+  var dockerFile = lines.join('\n');
+
+  var commands = dockerfileParser.parse(dockerFile);
+  t.equal(commands.length, 2);
+  t.deepEqual(commands[1].args, 'wget http://google.com?hello=world');
+
+  t.end();
+});


### PR DESCRIPTION
All tests passing:
```
# correctly parses commands with question mark
ok 27 should be equal
ok 28 should be equivalent

1..28
# tests 28
# pass  28
```