### PR TITLE
Ignore invalid inline comments #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-file-parser",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Parses a Dockerfile and returns an array of commands.",
   "keywords": [
     "dockerfile",

--- a/parser.js
+++ b/parser.js
@@ -11,6 +11,7 @@
 var TOKEN_WHITESPACE        = RegExp(/[\t\v\f\r ]+/);
 var TOKEN_LINE_CONTINUATION = RegExp(/\\[ \t]*$/);
 var TOKEN_COMMENT           = RegExp(/^#.*$/);
+var TOKEN_INLINE_COMMENT    = RegExp(/^[ \t]+#.*$/);
 var TOKEN_ESCAPE_DIRECTIVE  = RegExp(/^#[ \t]*escape[ \t]*=[ \t]*(.).*$/);
 
 var errDockerfileNotStringArray = new Error('When using JSON array syntax, '
@@ -379,10 +380,15 @@ function parse(contents, options) {
 
     for (i = 0; i < lines.length; i++) {
         lineno = i + 1;
+        var nextLine = lines[i];
+        // remove inline RUN # comment see https://github.com/joyent/node-docker-file-parser/issues/8
+        if (nextLine.match(TOKEN_INLINE_COMMENT)) {
+            nextLine = "\\";
+        }
         if (remainder) {
-            line = remainder + lines[i];
+            line = remainder + nextLine;
         } else {
-            line = lines[i];
+            line = nextLine;
         }
 
         if (lookingForDirectives) {

--- a/test/Dockerfile-with-inline-comment
+++ b/test/Dockerfile-with-inline-comment
@@ -1,0 +1,5 @@
+FROM quarry/monnode
+RUN cd /srv/app && \
+    # inline comment
+    make build2
+ENTRYPOINT node index.js

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -183,3 +183,13 @@ tape('correctly parses commands with question mark', function (t) {
 
   t.end();
 });
+
+tape('inline comments', function (t) {
+
+  var dname = __dirname;
+  var dockerFile = fs.readFileSync(dname + '/Dockerfile-with-inline-comment', 'utf8');
+  var commands = dockerfileParser.parse(dockerFile);
+
+  t.equal(commands[1].lineno, 4,  'Line number should be 4');
+  t.end();
+});


### PR DESCRIPTION
This is an attempt to fix #8 where an inline comment inside a RUN instruction is being detected as a COMMENT and not as a continuation, and the line numbers get all messed up

This removes the inline comment from the parsed-args because as far as I can tell, it's not a valid shell command but does somehow work with `docker build`